### PR TITLE
[feat] : 이미지 업로드 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### .yml ###
 *.yml
+application-local.yml
+
+# GCS 서비스 키
+stagemate_gcs.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ out/
 .vscode/
 
 ### .yml ###
-*.yml
+#*.yml
 application-local.yml
 
 # GCS 서비스 키

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	//webdriver-manager
 	implementation 'io.github.bonigarcia:webdrivermanager:5.8.0'
 
+	// 이미지 업로드를 위한 google cloud storage 의존성 추가
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/stagemate/domain/image/Image.java
+++ b/src/main/java/com/example/stagemate/domain/image/Image.java
@@ -1,0 +1,23 @@
+package com.example.stagemate.domain.image;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "images")
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+    private String imageUrl;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/stagemate/global/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/com/example/stagemate/global/config/GoogleCloudStorageConfig.java
@@ -1,0 +1,25 @@
+package com.example.stagemate.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import com.google.cloud.storage.Storage;
+import java.io.IOException;
+
+@Configuration
+public class GoogleCloudStorageConfig {
+    @Bean
+    public Storage storage() throws IOException {
+
+        ClassPathResource resource = new ClassPathResource("stagemate_gcs.json");
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+        String projectId = "stagemate-prod";
+        return StorageOptions.newBuilder()
+                .setProjectId(projectId)
+                .setCredentials(credentials)
+                .build()
+                .getService();
+    }
+}

--- a/src/main/java/com/example/stagemate/global/exception/image/ImageErrorCode.java
+++ b/src/main/java/com/example/stagemate/global/exception/image/ImageErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.stagemate.global.exception.image;
+
+import com.example.stagemate.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", "IMAGE-001"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/com/example/stagemate/global/exception/image/ImageUploadFailException.java
+++ b/src/main/java/com/example/stagemate/global/exception/image/ImageUploadFailException.java
@@ -1,0 +1,10 @@
+package com.example.stagemate.global.exception.image;
+
+import com.example.stagemate.global.exception.AppException;
+import com.example.stagemate.global.exception.ErrorCode;
+
+public class ImageUploadFailException extends AppException {
+    public ImageUploadFailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/stagemate/repository/ImageRepository.java
+++ b/src/main/java/com/example/stagemate/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.image.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/com/example/stagemate/service/image/ImageService.java
+++ b/src/main/java/com/example/stagemate/service/image/ImageService.java
@@ -1,0 +1,63 @@
+package com.example.stagemate.service.image;
+
+import com.example.stagemate.domain.image.Image;
+import com.example.stagemate.global.exception.image.ImageUploadFailException;
+import com.example.stagemate.repository.ImageRepository;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.example.stagemate.global.exception.image.ImageErrorCode.IMAGE_UPLOAD_FAILED;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageService {
+    private final Storage storage;
+    private final ImageRepository imageRepository;
+
+    @Value("${spring.cloud.gcp.storage.bucket}") // application.yml에 써둔 bucket 이름
+    private String bucketName;
+
+    @Value("${spring.cloud.gcp.storage.project-id}")
+    private String projectId;
+
+    public Image uploadImage(MultipartFile input) {
+
+        String fileName = UUID.randomUUID().toString(); // UUID를 이용해 고유한 파일 이름 생성
+        String ext = input.getContentType();
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fileName)
+                .setContentType(ext)
+                .build();
+
+
+        try {
+            // GCP Storage에 파일 업로드
+            storage.create(blobInfo, input.getInputStream());
+
+            // 업로드된 파일의 URL 생성
+            String imageUrl = "https://storage.googleapis.com/" + bucketName + "/" + fileName;
+
+            // 이미지 정보를 저장소에 저장
+            Image image = Image.builder()
+                    .imageUrl(imageUrl)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            return imageRepository.save(image); // 이미지 엔티티를 저장하고 반환
+
+        } catch (IOException e) {
+            throw new ImageUploadFailException(IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=stagemate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

Google Cloud Storage 연동 및 이미지 업로드 기능 구현
생성된 URL을 Image 엔티티로 DB에 저장
GCS 설정 정보(bucket, project-id, credentials)는 application-local.yml에 분리하여 관리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸스크린샷 (선택)
<img width="1126" alt="스크린샷 2025-07-05 오후 3 09 00" src="https://github.com/user-attachments/assets/61a72a6c-d22e-412f-ad81-1a7395f5dc39" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
