### PR TITLE
Feat/magazine

### DIFF
--- a/src/main/java/com/example/stagemate/controller/MagazineController.java
+++ b/src/main/java/com/example/stagemate/controller/MagazineController.java
@@ -38,7 +38,7 @@ public class MagazineController {
     @Operation(
             summary = "매거진 작성",
             description = """
-        매거진 정보를 JSON 문자열로 입력하고, 여러 이미지를 함께 업로드합니다.
+        매거진 정보를 JSON 문자열로 입력하고, 여러 이미지를 함께 업로드합니다. 이미지를 업로드하지 않는 경우 url에 "basic" 출력
 
         🔽 예시 JSON (request 필드 입력값):
 
@@ -74,7 +74,7 @@ public class MagazineController {
                             array = @ArraySchema(schema = @Schema(type = "string", format = "binary"))
                     )
             )
-            @RequestPart("images") List<MultipartFile> images
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
 
     ) throws JsonProcessingException {
 
@@ -136,10 +136,49 @@ public class MagazineController {
     }
 
 
-
     // 매거진 좋아요
+    @Operation(summary = "매거진 좋아요", description = "매거진에 좋아요를 누릅니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요 성공"),
+            @ApiResponse(responseCode = "404", description = "매거진을 찾을 수 없음 (MAGAZINE-002)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            // 유저를 찾을 수 없음
+//            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음 (USER-001)",
+//                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{magazineId}/likes")
+    public ResponseEntity<DataResponse<Void>> likeMagazine(
+            @PathVariable Long magazineId,
+            @RequestParam Long userId) { // 일단 userId를 요청 파라미터로 받음
+        magazineService.likeMagazine(magazineId, userId);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
 
     // 매거진 스크랩
+    @Operation(summary = "매거진 스크랩", description = "매거진을 스크랩합니다. 스크랩은 좋아요와 별개로 저장됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요 성공"),
+            @ApiResponse(responseCode = "404", description = "매거진을 찾을 수 없음 (MAGAZINE-002)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            // 유저를 찾을 수 없음
+//            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음 (USER-001)",
+//                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/{magazineId}/scraps")
+    public ResponseEntity<DataResponse<Void>> scrapMagazine(
+            @PathVariable Long magazineId,
+            @RequestParam Long userId) { // 일단 userId를 요청 파라미터로 받음
+        magazineService.scrapMagazine(magazineId, userId);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
 
     // 좋아요 + 스크랩 많은 순 추천 매거진 4개 보여주기
+    @Operation(summary = "추천 매거진 조회", description = "좋아요와 스크랩의 합이 높은 순으로 매거진 4개를 추천합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "추천 매거진 조회 성공"),
+    })
+    @GetMapping("/recommend")
+    public ResponseEntity<DataResponse<List<MagazineListResponse>>> getRecommendedMagazines() {
+        return ResponseEntity.ok(DataResponse.from(magazineService.getRecommendedMagazines()));
+    }
 }

--- a/src/main/java/com/example/stagemate/controller/MagazineController.java
+++ b/src/main/java/com/example/stagemate/controller/MagazineController.java
@@ -1,0 +1,145 @@
+package com.example.stagemate.controller;
+
+import com.example.stagemate.domain.magazine.MagazineCreateForm;
+import com.example.stagemate.dto.request.MagazineCreateRequest;
+import com.example.stagemate.dto.response.MagazineListResponse;
+import com.example.stagemate.dto.response.MagazinePagedResponse;
+import com.example.stagemate.dto.response.MagazineResponse;
+import com.example.stagemate.global.dto.DataResponse;
+import com.example.stagemate.global.dto.ErrorResponse;
+import com.example.stagemate.service.magazine.MagazineService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/v1/magazines")
+@RequiredArgsConstructor
+@Tag(name = "MagazineController", description = "Magazine 관련 API")
+public class MagazineController {
+
+    private final MagazineService magazineService;
+    private final ObjectMapper objectMapper;
+
+    @Operation(
+            summary = "매거진 작성",
+            description = """
+        매거진 정보를 JSON 문자열로 입력하고, 여러 이미지를 함께 업로드합니다.
+
+        🔽 예시 JSON (request 필드 입력값):
+
+        ```json
+        {
+          "title": "프랑스 배경 연극 추천",
+          "subTitle": "프랑스 중세시대 이야기",
+          "content": "안녕하세요. 최근에 프랑스 배경으로 연극이 많이 나오고 있습니다. 오늘 추천할 프랑스 배경 연극 추천은요...",
+          "category": "연극"
+        }
+        ```
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "매거진 작성 성공"),
+            @ApiResponse(responseCode = "404", description = "카테고리를 찾을 수 없음 (MAGAZINE-001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러 (COMMON-005)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DataResponse<MagazineResponse>> createMagazine(
+            @Parameter(
+                    description = "매거진 작성 요청 정보 (JSON 문자열)",
+                    required = true
+            )
+            @RequestPart("request") String requestJson,
+            @Parameter(
+                    description = "업로드할 이미지 파일들 (여러 개 가능)",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                            array = @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+                    )
+            )
+            @RequestPart("images") List<MultipartFile> images
+
+    ) throws JsonProcessingException {
+
+        MagazineCreateRequest request = objectMapper.readValue(requestJson, MagazineCreateRequest.class);
+        MagazineResponse response = magazineService.createMagazine(request, images);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+
+    // 최신 순 4개 보여주기
+    @Operation(summary = "최신 매거진 4개 조회", description = "작성일 기준 최신 매거진 4개를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "매거진 목록 최신순 4개 조회 성공"),
+    })
+    @GetMapping("/latest")
+    public ResponseEntity<DataResponse<List<MagazineListResponse>>> getLatestMagazines() {
+        List<MagazineListResponse> magazines = magazineService.getLatestMagazines();
+        return ResponseEntity.ok(DataResponse.from(magazines));
+    }
+
+    // 매거진 상세 보기
+    @Operation(summary = "매거진 상세 조회", description = "매거진 ID로 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "매거진을 찾을 수 없음 (MAGAZINE-002)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{magazineId}")
+    public ResponseEntity<DataResponse<MagazineResponse>> getMagazineDetail(@PathVariable Long magazineId) {
+        MagazineResponse magazine = magazineService.getMagazineDetail(magazineId);
+        return ResponseEntity.ok(DataResponse.from(magazine));
+    }
+
+    // 매거진 목록 보기(6개씩 페이징), 페이지 1부터 시작
+    @Operation(summary = "매거진 목록 조회 (페이징)", description = "매거진을 페이지 단위로 조회합니다. 페이지는 1부터 시작합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "매거진 목록 페이지 단위 조회 성공"),
+    })
+    @GetMapping
+    public ResponseEntity<DataResponse<MagazinePagedResponse>> getMagazines(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        MagazinePagedResponse magazines = magazineService.getMagazineList(page, size);
+        return ResponseEntity.ok(DataResponse.from(magazines));
+    }
+
+    // 매거진 삭제하기
+    @Operation(summary = "매거진 삭제", description = "매거진 ID로 매거진을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "매거진을 찾을 수 없음 (MAGAZINE-002)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/{magazineId}")
+    public ResponseEntity<DataResponse<Void>> deleteMagazine(@PathVariable Long magazineId) {
+        magazineService.deleteMagazine(magazineId);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+
+
+    // 매거진 좋아요
+
+    // 매거진 스크랩
+
+    // 좋아요 + 스크랩 많은 순 추천 매거진 4개 보여주기
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/Magazine.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/Magazine.java
@@ -1,0 +1,34 @@
+package com.example.stagemate.domain.magazine;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "magazines")
+public class Magazine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_id")
+    private Long id;
+    private String title;
+    private String subTitle;
+    private String content;
+    private LocalDateTime createdAt;
+    @Enumerated(EnumType.STRING)
+    private MagazineCategory category;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<MagazineImage> images = new ArrayList<>();
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/Magazine.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/Magazine.java
@@ -31,4 +31,12 @@ public class Magazine {
     @Builder.Default
     @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
     List<MagazineImage> images = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<MagazineLike> likes = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "magazine", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<MagazineScrap> scraps = new ArrayList<>();
 }

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineCategory.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineCategory.java
@@ -1,0 +1,33 @@
+package com.example.stagemate.domain.magazine;
+
+import com.example.stagemate.global.exception.magazine.MagazineCategoryNotFoundException;
+import lombok.Getter;
+
+import static com.example.stagemate.global.exception.magazine.MagazineErrorCode.CATEGORY_NOT_FOUND;
+
+@Getter
+public enum MagazineCategory {
+    EVENT("이벤트"),
+    NEWS("뉴스"),
+    MUSICAL("뮤지컬"),
+    PLAY("연극"),
+    ETC("기타");
+
+    private String description;
+
+    MagazineCategory(String description) {
+        this.description = description;
+    }
+
+    // request의 카테고리를 MagazineCategory enum으로 변환(한국어 -> 영어)
+    public static MagazineCategory from(String category) {
+        System.out.println(category);
+        for (MagazineCategory magazineCategory : MagazineCategory.values()) {
+            if (magazineCategory.getDescription().equals(category)) {
+                System.out.println("매거진 카테고리: " + magazineCategory);
+                return magazineCategory;
+            }
+        }
+        throw new MagazineCategoryNotFoundException(CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineCreateForm.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineCreateForm.java
@@ -1,0 +1,24 @@
+package com.example.stagemate.domain.magazine;
+
+import com.example.stagemate.dto.request.MagazineCreateRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+// swagger 문서화를 위한 요청 DTO (문서화 전용)
+@Schema(name = "MagazineCreateForm", description = "매거진 생성 폼")
+@Getter
+public class MagazineCreateForm {
+
+    private String title;
+    private String subTitle;
+    private String content;
+    private String category;
+
+    @Schema(description = "이미지 파일들", type = "array", format = "binary")
+    private List<MultipartFile> images = new ArrayList<>();
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineImage.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineImage.java
@@ -1,0 +1,32 @@
+package com.example.stagemate.domain.magazine;
+
+import com.example.stagemate.domain.image.Image;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "magazine_images")
+public class MagazineImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_image_id")
+    private Long id;
+
+    private int sortOrder;
+
+    @ManyToOne
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @ManyToOne
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineLike.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineLike.java
@@ -1,0 +1,33 @@
+package com.example.stagemate.domain.magazine;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "magazine_like")
+public class MagazineLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId; // 일단 userId 저장 -> 추후 User 엔티티와 연관관계 설정 예정
+
+    @ManyToOne
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+    // of 메서드로 객체 생성
+    public static MagazineLike of(Long userId, Magazine magazine) {
+        return MagazineLike.builder()
+                .userId(userId)
+                .magazine(magazine)
+                .build();
+    }
+}

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineScrap.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineScrap.java
@@ -1,0 +1,33 @@
+package com.example.stagemate.domain.magazine;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "magazine_scrap")
+public class MagazineScrap {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId; // 일단 userId 저장 -> 추후 User 엔티티와 연관관계 설정 예정
+
+    @ManyToOne
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+    // of 메서드로 객체 생성
+    public static MagazineScrap of(Long userId, Magazine magazine) {
+        return MagazineScrap.builder()
+                .userId(userId)
+                .magazine(magazine)
+                .build();
+    }
+}

--- a/src/main/java/com/example/stagemate/dto/request/MagazineCreateRequest.java
+++ b/src/main/java/com/example/stagemate/dto/request/MagazineCreateRequest.java
@@ -1,0 +1,35 @@
+package com.example.stagemate.dto.request;
+
+import com.example.stagemate.domain.magazine.Magazine;
+import com.example.stagemate.domain.magazine.MagazineCategory;
+import com.example.stagemate.domain.magazine.MagazineCreateForm;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MagazineCreateRequest {
+    private String title;
+    private String subTitle;
+    private String content;
+    private String category;
+
+    public static MagazineCreateRequest from(MagazineCreateForm form) {
+        MagazineCreateRequest request = new MagazineCreateRequest();
+        request.title = form.getTitle();
+        request.subTitle = form.getSubTitle();
+        request.content = form.getContent();
+        request.category = form.getCategory();
+        return request;
+    }
+
+    public Magazine toEntity(MagazineCategory magazineCategory) {
+        return Magazine.builder()
+                .title(title)
+                .subTitle(subTitle)
+                .content(content)
+                .category(magazineCategory)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/stagemate/dto/response/MagazineListResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/MagazineListResponse.java
@@ -1,0 +1,23 @@
+package com.example.stagemate.dto.response;
+
+import com.example.stagemate.domain.magazine.Magazine;
+
+import java.util.List;
+
+public record MagazineListResponse(
+        Long id,
+        String title,
+        String subTitle,
+        String imageUrl, // 맨 처음 이미지만 보이게
+        String category
+) {
+    public static MagazineListResponse from(Magazine magazine) {
+        return new MagazineListResponse(
+                magazine.getId(),
+                magazine.getTitle(),
+                magazine.getSubTitle(),
+                magazine.getImages().isEmpty() ? "basic" : magazine.getImages().get(0).getImage().getImageUrl(),
+                magazine.getCategory().name()
+        );
+    }
+}

--- a/src/main/java/com/example/stagemate/dto/response/MagazinePagedResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/MagazinePagedResponse.java
@@ -1,0 +1,12 @@
+package com.example.stagemate.dto.response;
+
+import java.util.List;
+
+public record MagazinePagedResponse(
+        List<MagazineListResponse> list,
+        int currentPage,
+        int pageSize,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/example/stagemate/dto/response/MagazineResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/MagazineResponse.java
@@ -1,0 +1,27 @@
+package com.example.stagemate.dto.response;
+
+import com.example.stagemate.domain.magazine.Magazine;
+
+import java.util.List;
+
+public record MagazineResponse(
+        Long id,
+        String title,
+        String subTitle,
+        String content,
+        List<String> imageUrls,
+        String category,
+        String createdAt
+) {
+    public static MagazineResponse from(Magazine magazine) {
+        return new MagazineResponse(
+                magazine.getId(),
+                magazine.getTitle(),
+                magazine.getSubTitle(),
+                magazine.getContent(),
+                magazine.getImages().isEmpty() ? List.of("basic") : magazine.getImages().stream().map(image -> image.getImage().getImageUrl()).toList(),
+                magazine.getCategory().name(),
+                magazine.getCreatedAt().toString()
+            );
+    }
+}

--- a/src/main/java/com/example/stagemate/dto/response/MagazineResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/MagazineResponse.java
@@ -11,7 +11,9 @@ public record MagazineResponse(
         String content,
         List<String> imageUrls,
         String category,
-        String createdAt
+        String createdAt,
+        int likeCount,
+        int scrapCount
 ) {
     public static MagazineResponse from(Magazine magazine) {
         return new MagazineResponse(
@@ -21,7 +23,9 @@ public record MagazineResponse(
                 magazine.getContent(),
                 magazine.getImages().isEmpty() ? List.of("basic") : magazine.getImages().stream().map(image -> image.getImage().getImageUrl()).toList(),
                 magazine.getCategory().name(),
-                magazine.getCreatedAt().toString()
+                magazine.getCreatedAt().toString(),
+                magazine.getLikes() == null ? 0 : magazine.getLikes().size(),
+                magazine.getScraps() == null ? 0 : magazine.getScraps().size()
             );
     }
 }

--- a/src/main/java/com/example/stagemate/global/exception/magazine/MagazineCategoryNotFoundException.java
+++ b/src/main/java/com/example/stagemate/global/exception/magazine/MagazineCategoryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.stagemate.global.exception.magazine;
+
+import com.example.stagemate.global.exception.AppException;
+import com.example.stagemate.global.exception.ErrorCode;
+
+public class MagazineCategoryNotFoundException extends AppException {
+    public MagazineCategoryNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/stagemate/global/exception/magazine/MagazineErrorCode.java
+++ b/src/main/java/com/example/stagemate/global/exception/magazine/MagazineErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.stagemate.global.exception.magazine;
+
+import com.example.stagemate.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MagazineErrorCode implements ErrorCode {
+    // 매거진 카테고리 없음
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "매거진 카테고리를 찾을 수 없습니다.", "MAGAZINE-001"),
+    // 매거진 없음
+    MAGAZINE_NOT_FOUND(HttpStatus.NOT_FOUND, "매거진을 찾을 수 없습니다.", "MAGAZINE-002"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/com/example/stagemate/global/exception/magazine/MagazineNotFoundException.java
+++ b/src/main/java/com/example/stagemate/global/exception/magazine/MagazineNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.stagemate.global.exception.magazine;
+
+import com.example.stagemate.global.exception.AppException;
+import com.example.stagemate.global.exception.ErrorCode;
+
+public class MagazineNotFoundException extends AppException {
+    public MagazineNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/stagemate/repository/MagazineImageRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.magazine.MagazineImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineImageRepository extends JpaRepository<MagazineImage, Long> {
+}

--- a/src/main/java/com/example/stagemate/repository/MagazineLikeRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineLikeRepository.java
@@ -1,0 +1,9 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.magazine.MagazineLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineLikeRepository extends JpaRepository<MagazineLike, Long> {
+    boolean existsByUserIdAndMagazineId(Long userId, Long magazineId);
+    void deleteByUserIdAndMagazineId(Long userId, Long magazineId);
+}

--- a/src/main/java/com/example/stagemate/repository/MagazineRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineRepository.java
@@ -4,6 +4,7 @@ import com.example.stagemate.domain.magazine.Magazine;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,4 +12,14 @@ import java.util.List;
 public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     List<Magazine> findAllByOrderByCreatedAtDesc();
     Page<Magazine> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("""
+        SELECT m
+        FROM Magazine m
+        LEFT JOIN m.likes l
+        LEFT JOIN m.scraps s
+        GROUP BY m
+        ORDER BY COUNT(l) + COUNT(s) DESC, m.createdAt DESC
+    """)
+    List<Magazine> findTop4ByLikesAndScrapsSum(Pageable pageable);
+
 }

--- a/src/main/java/com/example/stagemate/repository/MagazineRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineRepository.java
@@ -1,0 +1,14 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.magazine.Magazine;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface MagazineRepository extends JpaRepository<Magazine, Long> {
+    List<Magazine> findAllByOrderByCreatedAtDesc();
+    Page<Magazine> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/example/stagemate/repository/MagazineScrapRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineScrapRepository.java
@@ -1,0 +1,9 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.magazine.MagazineScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MagazineScrapRepository extends JpaRepository<MagazineScrap, Long> {
+    boolean existsByUserIdAndMagazineId(Long userId, Long magazineId);
+    void deleteByUserIdAndMagazineId(Long userId, Long magazineId);
+}

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
@@ -1,17 +1,13 @@
 package com.example.stagemate.service.magazine;
 
 import com.example.stagemate.domain.image.Image;
-import com.example.stagemate.domain.magazine.Magazine;
-import com.example.stagemate.domain.magazine.MagazineCategory;
-import com.example.stagemate.domain.magazine.MagazineImage;
+import com.example.stagemate.domain.magazine.*;
 import com.example.stagemate.dto.request.MagazineCreateRequest;
 import com.example.stagemate.dto.response.MagazineListResponse;
 import com.example.stagemate.dto.response.MagazinePagedResponse;
 import com.example.stagemate.dto.response.MagazineResponse;
 import com.example.stagemate.global.exception.magazine.MagazineNotFoundException;
-import com.example.stagemate.repository.ImageRepository;
-import com.example.stagemate.repository.MagazineImageRepository;
-import com.example.stagemate.repository.MagazineRepository;
+import com.example.stagemate.repository.*;
 import com.example.stagemate.service.image.ImageService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +29,8 @@ public class MagazineService {
     private final ImageService imageService; // 이미지 업로드 서비스
     private final ImageRepository imageRepository;
     private final MagazineImageRepository magazineImageRepository;
+    private final MagazineLikeRepository magazineLikeRepository;
+    private final MagazineScrapRepository magazineScrapRepository;
 
     // 매거진 생성(사진 여러개 포함)
     public MagazineResponse createMagazine(MagazineCreateRequest request, List<MultipartFile> images) {
@@ -40,21 +38,23 @@ public class MagazineService {
         Magazine entity = request.toEntity(magazineCategory);
         magazineRepository.save(entity);
 
-        int order = 1;
-        // 이미지 저장
-        for(MultipartFile image : images) {
-            Image uploadImage = imageService.uploadImage(image);
+        if (images != null && !images.isEmpty()) {
+            int order = 1;
+            // 이미지 저장
+            for (MultipartFile image : images) {
+                Image uploadImage = imageService.uploadImage(image);
 
-            // 중간 테이블 연결, 순서 포함
-            MagazineImage magazineImage = MagazineImage.builder()
-                    .magazine(entity)
-                    .image(uploadImage)
-                    .sortOrder(order++)
-                    .build();
-            magazineImageRepository.save(magazineImage);
+                // 중간 테이블 연결, 순서 포함
+                MagazineImage magazineImage = MagazineImage.builder()
+                        .magazine(entity)
+                        .image(uploadImage)
+                        .sortOrder(order++)
+                        .build();
+                magazineImageRepository.save(magazineImage);
 
-            // 매거진 연관관계 편의 메서드로 이미지 추가
-            entity.getImages().add(magazineImage);
+                // 매거진 연관관계 편의 메서드로 이미지 추가
+                entity.getImages().add(magazineImage);
+            }
         }
         // 매거진 응답 DTO 생성
         return MagazineResponse.from(entity);
@@ -105,5 +105,56 @@ public class MagazineService {
             imageRepository.delete(mi.getImage());
         }
         magazineRepository.delete(magazine);
+    }
+
+    // 매거진 좋아요
+    public void likeMagazine(Long magazineId, Long userId) {
+        // 매거진 존재하는지 확인
+        Magazine magazine = magazineRepository.findById(magazineId).orElseThrow(
+                () -> new MagazineNotFoundException(MAGAZINE_NOT_FOUND));
+        // 유저 존재하는지 확인
+        // User user = userRepository.findById(userId).orElseThrow(
+        //  () -> new UserNotFoundException(USER_NOT_FOUND));
+
+        if(magazineLikeRepository.existsByUserIdAndMagazineId(userId, magazineId)) {
+            // 이미 좋아요를 누른 경우
+            magazineLikeRepository.deleteByUserIdAndMagazineId(userId, magazineId);
+            magazine.getLikes().removeIf(like -> like.getUserId().equals(userId));
+        } else {
+            // 좋아요를 누르지 않은 경우
+            MagazineLike magazineLike = magazineLikeRepository.save(MagazineLike.of(userId, magazine));
+            magazine.getLikes().add(magazineLike);
+        }
+    }
+
+    // 매거진 스크랩
+    public void scrapMagazine(Long magazineId, Long userId) {
+        // 매거진 존재하는지 확인
+        Magazine magazine = magazineRepository.findById(magazineId).orElseThrow(
+                () -> new MagazineNotFoundException(MAGAZINE_NOT_FOUND));
+        // 유저 존재하는지 확인
+        // User user = userRepository.findById(userId).orElseThrow(
+        //  () -> new UserNotFoundException(USER_NOT_FOUND));
+
+        if(magazineScrapRepository.existsByUserIdAndMagazineId(userId, magazineId)) {
+            // 이미 좋아요를 누른 경우
+            magazineScrapRepository.deleteByUserIdAndMagazineId(userId, magazineId);
+            magazine.getScraps().removeIf(scrap -> scrap.getUserId().equals(userId));
+        } else {
+            // 좋아요를 누르지 않은 경우
+            MagazineScrap magazineScrap = magazineScrapRepository.save(MagazineScrap.of(userId, magazine));
+            magazine.getScraps().add(magazineScrap);
+        }
+    }
+
+    // 좋아요 + 스크랩 많은 순 추천 매거진 4개 보여주기
+    // 같은 수일 경우, 최신 순으로 정렬
+    public List<MagazineListResponse> getRecommendedMagazines() {
+        Pageable pageable = PageRequest.of(0, 4);
+        List<Magazine> magazines = magazineRepository.findTop4ByLikesAndScrapsSum(pageable);
+        return magazines.stream()
+                .map(MagazineListResponse::from)
+                .toList();
+
     }
 }

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
@@ -1,0 +1,109 @@
+package com.example.stagemate.service.magazine;
+
+import com.example.stagemate.domain.image.Image;
+import com.example.stagemate.domain.magazine.Magazine;
+import com.example.stagemate.domain.magazine.MagazineCategory;
+import com.example.stagemate.domain.magazine.MagazineImage;
+import com.example.stagemate.dto.request.MagazineCreateRequest;
+import com.example.stagemate.dto.response.MagazineListResponse;
+import com.example.stagemate.dto.response.MagazinePagedResponse;
+import com.example.stagemate.dto.response.MagazineResponse;
+import com.example.stagemate.global.exception.magazine.MagazineNotFoundException;
+import com.example.stagemate.repository.ImageRepository;
+import com.example.stagemate.repository.MagazineImageRepository;
+import com.example.stagemate.repository.MagazineRepository;
+import com.example.stagemate.service.image.ImageService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.example.stagemate.global.exception.magazine.MagazineErrorCode.MAGAZINE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MagazineService {
+    private final MagazineRepository magazineRepository;
+    private final ImageService imageService; // 이미지 업로드 서비스
+    private final ImageRepository imageRepository;
+    private final MagazineImageRepository magazineImageRepository;
+
+    // 매거진 생성(사진 여러개 포함)
+    public MagazineResponse createMagazine(MagazineCreateRequest request, List<MultipartFile> images) {
+        MagazineCategory magazineCategory = MagazineCategory.from(request.getCategory());
+        Magazine entity = request.toEntity(magazineCategory);
+        magazineRepository.save(entity);
+
+        int order = 1;
+        // 이미지 저장
+        for(MultipartFile image : images) {
+            Image uploadImage = imageService.uploadImage(image);
+
+            // 중간 테이블 연결, 순서 포함
+            MagazineImage magazineImage = MagazineImage.builder()
+                    .magazine(entity)
+                    .image(uploadImage)
+                    .sortOrder(order++)
+                    .build();
+            magazineImageRepository.save(magazineImage);
+
+            // 매거진 연관관계 편의 메서드로 이미지 추가
+            entity.getImages().add(magazineImage);
+        }
+        // 매거진 응답 DTO 생성
+        return MagazineResponse.from(entity);
+    }
+
+    // 최신 순 4개 보여주기
+    public List<MagazineListResponse> getLatestMagazines() {
+        List<Magazine> magazines = magazineRepository.findAllByOrderByCreatedAtDesc();
+        return magazines.stream()
+                .map(MagazineListResponse::from)
+                .limit(4)
+                .toList();
+    }
+
+
+    // 매거진 목록 조회 (6개씩 페이징)
+    public MagazinePagedResponse getMagazineList(int page, int size) {
+        Pageable pageable = PageRequest.of(page-1, size);
+        Page<Magazine> magazinePage = magazineRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        List<MagazineListResponse> content = magazinePage.getContent().stream()
+                .map(MagazineListResponse::from)
+                .toList();
+        return new MagazinePagedResponse(
+                content,
+                magazinePage.getNumber(),
+                magazinePage.getSize(),
+                magazinePage.getTotalElements(),
+                magazinePage.getTotalPages()
+        );
+    }
+
+    // 매거진 상세 조회
+    public MagazineResponse getMagazineDetail(Long id) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new MagazineNotFoundException(MAGAZINE_NOT_FOUND));
+
+        return MagazineResponse.from(magazine);
+    }
+
+
+
+    // 매거진 삭제
+    public void deleteMagazine(Long id) {
+        Magazine magazine = magazineRepository.findById(id)
+                .orElseThrow(() -> new MagazineNotFoundException(MAGAZINE_NOT_FOUND));
+        for (MagazineImage mi : magazine.getImages()) {
+            imageRepository.delete(mi.getImage());
+        }
+        magazineRepository.delete(magazine);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
- MagazineController 전체 API 구현 완료
- 매거진 작성 (멀티파트 요청 처리 + JSON 파싱)
- 매거진 상세 조회 / 페이징 조회 / 최신 4개 조회
- 좋아요 / 스크랩 기능 구현
- 좋아요 + 스크랩 수 기반 추천 매거진 4개 조회 기능 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주석 추가 및 수정
- [x] 문서 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 매거진 작성 시 이미지를 업로드하지 않는 경우 기본 URL 처리("basic") 적용했습니다.
- 추천 매거진 조회 기능에서 좋아요 + 스크랩 수를 기준으로 정렬하는 로직을 stream으로 다 가져와서 정렬하는 방식은 성능이 좋지 않다고 판단되어 JPQL로 처리했습니다. 이 방식이 괜찮은지, 혹은 성능 상 더 나은 접근법이 있다면 피드백 부탁드립니다!
