### PR TITLE
[Feat] 인기 매거진 통계 스케줄러

### DIFF
--- a/src/main/java/com/example/stagemate/controller/MagazineController.java
+++ b/src/main/java/com/example/stagemate/controller/MagazineController.java
@@ -84,14 +84,16 @@ public class MagazineController {
     }
 
 
-    // 최신 순 4개 보여주기
-    @Operation(summary = "최신 매거진 4개 조회", description = "작성일 기준 최신 매거진 4개를 조회합니다.")
+    // 최신 순 매거진 보여주기
+    // 조회할 매거진 개수는 기본값 4
+    @Operation(summary = "최신 매거진 조회", description = "작성일 기준 최신 매거진(기본값 4)을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "매거진 목록 최신순 4개 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "최신순 매거진 목록 조회 성공"),
     })
     @GetMapping("/latest")
-    public ResponseEntity<DataResponse<List<MagazineListResponse>>> getLatestMagazines() {
-        List<MagazineListResponse> magazines = magazineService.getLatestMagazines();
+    public ResponseEntity<DataResponse<List<MagazineListResponse>>> getLatestMagazines(
+            @RequestParam(defaultValue = "4") int size) {
+        List<MagazineListResponse> magazines = magazineService.getLatestMagazines(size);
         return ResponseEntity.ok(DataResponse.from(magazines));
     }
 
@@ -108,7 +110,7 @@ public class MagazineController {
         return ResponseEntity.ok(DataResponse.from(magazine));
     }
 
-    // 매거진 목록 보기(6개씩 페이징), 페이지 1부터 시작
+    // 매거진 목록 보기(기본값 6개씩 페이징), 페이지 1부터 시작
     @Operation(summary = "매거진 목록 조회 (페이징)", description = "매거진을 페이지 단위로 조회합니다. 페이지는 1부터 시작합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "매거진 목록 페이지 단위 조회 성공"),

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineStatistics.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineStatistics.java
@@ -1,0 +1,43 @@
+package com.example.stagemate.domain.magazine;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "magazine_statistics")
+public class MagazineStatistics {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_statistics_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "magazine_id")
+    private Magazine magazine;
+
+    int likeCount;
+    int scrapCount;
+    int totalCount;
+    LocalDateTime updatedAt;
+
+    public static MagazineStatistics of(Magazine magazine) {
+        int likeCount = magazine.getLikes() == null ? 0 : magazine.getLikes().size();
+        int scrapCount = magazine.getScraps() == null ? 0 : magazine.getScraps().size();
+        return MagazineStatistics.builder()
+                .magazine(magazine)
+                .likeCount(likeCount)
+                .scrapCount(scrapCount)
+                .totalCount(likeCount + scrapCount)
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/stagemate/dto/response/MagazineListResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/MagazineListResponse.java
@@ -1,6 +1,7 @@
 package com.example.stagemate.dto.response;
 
 import com.example.stagemate.domain.magazine.Magazine;
+import com.example.stagemate.domain.magazine.MagazineStatistics;
 
 import java.util.List;
 

--- a/src/main/java/com/example/stagemate/repository/MagazineStatisticsRepository.java
+++ b/src/main/java/com/example/stagemate/repository/MagazineStatisticsRepository.java
@@ -1,0 +1,10 @@
+package com.example.stagemate.repository;
+
+import com.example.stagemate.domain.magazine.MagazineStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+
+public interface MagazineStatisticsRepository extends JpaRepository<MagazineStatistics, Long> {
+
+}

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
@@ -31,6 +31,7 @@ public class MagazineService {
     private final MagazineImageRepository magazineImageRepository;
     private final MagazineLikeRepository magazineLikeRepository;
     private final MagazineScrapRepository magazineScrapRepository;
+    private final MagazineStatisticsRepository magazineStatisticsRepository;
 
     // 매거진 생성(사진 여러개 포함)
     public MagazineResponse createMagazine(MagazineCreateRequest request, List<MultipartFile> images) {
@@ -150,9 +151,10 @@ public class MagazineService {
     // 좋아요 + 스크랩 많은 순 추천 매거진 4개 보여주기
     // 같은 수일 경우, 최신 순으로 정렬
     public List<MagazineListResponse> getRecommendedMagazines() {
-        Pageable pageable = PageRequest.of(0, 4);
-        List<Magazine> magazines = magazineRepository.findTop4ByLikesAndScrapsSum(pageable);
-        return magazines.stream()
+        // 매거진 통계 정보 가져오기
+        List<MagazineStatistics> statistics = magazineStatisticsRepository.findAll();
+        return statistics.stream()
+                .map(MagazineStatistics::getMagazine)
                 .map(MagazineListResponse::from)
                 .toList();
 

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
@@ -60,12 +60,12 @@ public class MagazineService {
         return MagazineResponse.from(entity);
     }
 
-    // 최신 순 4개 보여주기
-    public List<MagazineListResponse> getLatestMagazines() {
+    // 최신 순 매거진 보여주기
+    public List<MagazineListResponse> getLatestMagazines(int size) {
         List<Magazine> magazines = magazineRepository.findAllByOrderByCreatedAtDesc();
         return magazines.stream()
                 .map(MagazineListResponse::from)
-                .limit(4)
+                .limit(size)
                 .toList();
     }
 

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineStatisticsScheduler.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineStatisticsScheduler.java
@@ -1,0 +1,54 @@
+package com.example.stagemate.service.magazine;
+
+import com.example.stagemate.domain.magazine.Magazine;
+import com.example.stagemate.domain.magazine.MagazineStatistics;
+import com.example.stagemate.dto.response.MagazineListResponse;
+import com.example.stagemate.repository.MagazineRepository;
+import com.example.stagemate.repository.MagazineStatisticsRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MagazineStatisticsScheduler {
+    private final MagazineRepository magazineRepository;
+    private final MagazineStatisticsRepository magazineStatisticsRepository;
+
+    // 애플리케이션 시작 시 매거진 통계 초기화
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void initStatistics() {
+        updateMagazineStatistics();
+        log.info("애플리케이션 시작 시 매거진 통계 초기화 완료");
+    }
+
+
+    // 매거진 통계 업데이트 스케줄러
+    // 30분 단위 실행
+    @Transactional
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void updateMagazineStatistics() {
+        Pageable pageable = PageRequest.of(0, 4);
+        List<Magazine> magazines = magazineRepository.findTop4ByLikesAndScrapsSum(pageable);
+
+        // 기존 통계 삭제
+        magazineStatisticsRepository.deleteAll();
+
+        // 매거진 통계 테이블에 저장
+        magazines.stream()
+                .map(MagazineStatistics::of)
+                .forEach(magazineStatisticsRepository::save);
+        log.info("매거진 통계 업데이트 완료. 최신 4개 매거진 통계 저장됨.");
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
- 정렬 기준이 고정된 TOP 4만 보여주면 되므로, 인기 매거진 4개만 통계 테이블에 저장하고 30분마다 스케줄링으로 갱신하여 캐시처럼 활용
- 통계 갱신 중 테이블이 비는 현상을 방지하기 위해 @Transactional 설정
- 통계 조회 시 N+1 문제 방지를 위해 @ManyToOne(fetch = FetchType.EAGER)로 설정
- 애플리케이션 최초 실행 시 통계가 없을 수 있어 ApplicationReadyEvent로 초기 통계 한 번 생성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
