### PR TITLE
Fix/community

### DIFF
--- a/src/main/java/com/example/stagemate/controller/CommunityController.java
+++ b/src/main/java/com/example/stagemate/controller/CommunityController.java
@@ -108,7 +108,7 @@ public class CommunityController {
     public ResponseEntity<DataResponse<CommunityPostResponse>> getCommunityPostDetail(
             @PathVariable Long postId,
             @Parameter(hidden = true) @CurrentUser UserJpaEntity user
-    ) {
+    ) throws JsonProcessingException {
         CommunityPostResponse response = communityService.getCommunityPostDetail(
                 postId, user
         );

--- a/src/main/java/com/example/stagemate/controller/CommunityController.java
+++ b/src/main/java/com/example/stagemate/controller/CommunityController.java
@@ -49,7 +49,7 @@ public class CommunityController {
                     content = @Content(array = @ArraySchema(schema = @Schema(type = "string", format = "binary")))
             )
             List<MultipartFile> images,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) throws JsonProcessingException {
         CommunityPostCreateRequest request = objectMapper.readValue(requestJson, CommunityPostCreateRequest.class);
         CommunityPostResponse response = communityService.createCommunityPost(user, request, images);
@@ -62,7 +62,7 @@ public class CommunityController {
     public ResponseEntity<DataResponse<CommunityPostPagedResponse>> getCommunityHotPosts(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         CommunityPostPagedResponse response = communityService.getCommunityHotPosts(
                 user, page, size
@@ -78,7 +78,7 @@ public class CommunityController {
             @RequestParam String category,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         CommunityPostPagedResponse response = communityService.getCommunityPosts(
                 user, category, page, size
@@ -92,7 +92,7 @@ public class CommunityController {
     public ResponseEntity<DataResponse<CommunityPostTradePagedResponse>> getCommunityTradePosts(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         CommunityPostTradePagedResponse response = communityService.getCommunityTradePosts(
                 user, page, size
@@ -107,7 +107,7 @@ public class CommunityController {
     @GetMapping("/{postId}")
     public ResponseEntity<DataResponse<CommunityPostResponse>> getCommunityPostDetail(
             @PathVariable Long postId,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         CommunityPostResponse response = communityService.getCommunityPostDetail(
                 postId, user
@@ -120,7 +120,7 @@ public class CommunityController {
     @PostMapping("/{postId}/likes")
     public ResponseEntity<DataResponse<Void>> toggleCommunityPostLike(
             @PathVariable Long postId,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         communityService.toggleCommunityPostLike(postId, user);
         return ResponseEntity.ok(DataResponse.ok());
@@ -131,7 +131,7 @@ public class CommunityController {
     @PostMapping("/{postId}/scraps")
     public ResponseEntity<DataResponse<Void>> toggleCommunityPostScrap(
             @PathVariable Long postId,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         communityService.toggleCommunityPostScrap(postId, user);
         return ResponseEntity.ok(DataResponse.ok());
@@ -149,7 +149,7 @@ public class CommunityController {
                     content = @Content(array = @ArraySchema(schema = @Schema(type = "string", format = "binary")))
             )
             List<MultipartFile> newImages,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) throws JsonProcessingException {
         CommunityPostUpdateRequest request = objectMapper.readValue(requestJson, CommunityPostUpdateRequest.class);
         CommunityPostResponse response = communityService.updateCommunityPost(user, postId, request, newImages);
@@ -161,7 +161,7 @@ public class CommunityController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<DataResponse<Void>> deletePost(
             @PathVariable Long postId,
-            @CurrentUser UserJpaEntity user
+            @Parameter(hidden = true) @CurrentUser UserJpaEntity user
     ) {
         communityService.deleteCommunityPost(postId, user);
         return ResponseEntity.ok(DataResponse.ok());

--- a/src/main/java/com/example/stagemate/domain/community/CommunityPost.java
+++ b/src/main/java/com/example/stagemate/domain/community/CommunityPost.java
@@ -2,6 +2,7 @@ package com.example.stagemate.domain.community;
 
 import com.example.stagemate.domain.user.entity.UserJpaEntity;
 import com.example.stagemate.dto.request.community.CommunityPostUpdateRequest;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +31,8 @@ public class CommunityPost {
     @Enumerated(EnumType.STRING)
     private TradeMethod tradeMethod; // 나눔거래일떄 방법(추첨나눔/판매/선착나눔)
     private String title;
+    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
@@ -88,10 +91,10 @@ public class CommunityPost {
 
 
     // 나눔거래에서 다른 카테고리로 변경할 경우 고려
-    public void update(CommunityPostUpdateRequest request) {
+    public void update(CommunityPostUpdateRequest request, String jsonContent) {
         CommunityCategory communityCategory = CommunityCategory.from(request.getCategory());
         this.title = request.getTitle();
-        this.content = request.getContent();
+        this.content = jsonContent;
         this.category = communityCategory;
         this.tradeCategory = communityCategory==CommunityCategory.TRADE ? TradeCategory.from(request.getTradeCategory()) : null;
         this.tradeMethod = communityCategory==CommunityCategory.TRADE ? TradeMethod.from(request.getTradeMethod()) : null;

--- a/src/main/java/com/example/stagemate/domain/community/CommunityPost.java
+++ b/src/main/java/com/example/stagemate/domain/community/CommunityPost.java
@@ -37,7 +37,6 @@ public class CommunityPost {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
     public boolean membersOnly;
-    private boolean sendNotification;
     @Column(name = "is_deleted")
     @Builder.Default
     private boolean deleted = false;
@@ -97,6 +96,5 @@ public class CommunityPost {
         this.tradeCategory = communityCategory==CommunityCategory.TRADE ? TradeCategory.from(request.getTradeCategory()) : null;
         this.tradeMethod = communityCategory==CommunityCategory.TRADE ? TradeMethod.from(request.getTradeMethod()) : null;
         this.membersOnly = request.isMembersOnly();
-        this.sendNotification = request.isSendNotification();
     }
 }

--- a/src/main/java/com/example/stagemate/dto/request/community/CommunityPostCreateRequest.java
+++ b/src/main/java/com/example/stagemate/dto/request/community/CommunityPostCreateRequest.java
@@ -17,7 +17,6 @@ public class CommunityPostCreateRequest {
     private String tradeCategory; // 뮤지컬, 연극
     private String tradeMethod; // 추첨나눔, 판매, 선착나눔
     private boolean membersOnly;
-    private boolean sendNotification;
 
     public CommunityPost toEntity(UserJpaEntity user, CommunityCategory communityCategory, TradeCategory tradeCategory, TradeMethod tradeMethod) {
         return CommunityPost.builder()
@@ -28,7 +27,6 @@ public class CommunityPostCreateRequest {
                 .content(content)
                 .author(user)
                 .membersOnly(membersOnly)
-                .sendNotification(sendNotification)
 //                .isDeleted(false)
 //                .viewCount(0)
 //                .commentCount(0)

--- a/src/main/java/com/example/stagemate/dto/request/community/CommunityPostCreateRequest.java
+++ b/src/main/java/com/example/stagemate/dto/request/community/CommunityPostCreateRequest.java
@@ -5,6 +5,7 @@ import com.example.stagemate.domain.community.CommunityPost;
 import com.example.stagemate.domain.community.TradeCategory;
 import com.example.stagemate.domain.community.TradeMethod;
 import com.example.stagemate.domain.user.entity.UserJpaEntity;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,19 +13,19 @@ import java.time.LocalDateTime;
 @Getter
 public class CommunityPostCreateRequest {
     private String title;
-    private String content;
+    private JsonNode content;
     private String category; // 일상, 나눔거래, 꿀팁
     private String tradeCategory; // 뮤지컬, 연극
     private String tradeMethod; // 추첨나눔, 판매, 선착나눔
     private boolean membersOnly;
 
-    public CommunityPost toEntity(UserJpaEntity user, CommunityCategory communityCategory, TradeCategory tradeCategory, TradeMethod tradeMethod) {
+    public CommunityPost toEntity(UserJpaEntity user, CommunityCategory communityCategory, TradeCategory tradeCategory, TradeMethod tradeMethod, String jsonString) {
         return CommunityPost.builder()
                 .title(title)
                 .category(communityCategory)
                 .tradeCategory(tradeCategory) // 나눔거래가 아닐 경우 null
                 .tradeMethod(tradeMethod) // 나눔거래가 아닐 경우 null
-                .content(content)
+                .content(jsonString)
                 .author(user)
                 .membersOnly(membersOnly)
 //                .isDeleted(false)

--- a/src/main/java/com/example/stagemate/dto/request/community/CommunityPostUpdateRequest.java
+++ b/src/main/java/com/example/stagemate/dto/request/community/CommunityPostUpdateRequest.java
@@ -12,6 +12,5 @@ public class CommunityPostUpdateRequest {
     private String tradeCategory; // 뮤지컬, 연극
     private String tradeMethod; // 추첨나눔, 판매, 선착나눔
     private boolean membersOnly;
-    private boolean sendNotification;
     private List<Long> imageIds; // 삭제하지 않은 기존 이미지 ID 목록
 }

--- a/src/main/java/com/example/stagemate/dto/request/community/CommunityPostUpdateRequest.java
+++ b/src/main/java/com/example/stagemate/dto/request/community/CommunityPostUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.example.stagemate.dto.request.community;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.List;
 @Getter
 public class CommunityPostUpdateRequest {
     private String title;
-    private String content;
+    private JsonNode content;
     private String category; // 일상, 나눔거래, 꿀팁
     private String tradeCategory; // 뮤지컬, 연극
     private String tradeMethod; // 추첨나눔, 판매, 선착나눔

--- a/src/main/java/com/example/stagemate/dto/response/community/CommunityPostResponse.java
+++ b/src/main/java/com/example/stagemate/dto/response/community/CommunityPostResponse.java
@@ -1,6 +1,7 @@
 package com.example.stagemate.dto.response.community;
 
 import com.example.stagemate.domain.community.CommunityPost;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ import java.util.List;
 public class CommunityPostResponse {
     private Long id;
     String title;
-    String content;
+    JsonNode content;
     String authorName;
     LocalDateTime createdAt;
     int viewCount;
@@ -27,11 +28,11 @@ public class CommunityPostResponse {
     boolean isLiked;
     boolean membersOnly;
 
-    public static CommunityPostResponse from(CommunityPost post, boolean isScrapped, boolean isLiked) {
+    public static CommunityPostResponse from(CommunityPost post, boolean isScrapped, boolean isLiked, JsonNode jsonContent) {
         return new CommunityPostResponse(
                 post.getId(),
                 post.getTitle(),
-                post.getContent(),
+                jsonContent,
                 post.getAuthor().getNickname(),
                 post.getCreatedAt(),
                 post.getViewCount(),

--- a/src/main/java/com/example/stagemate/global/auth/SecurityConfig.java
+++ b/src/main/java/com/example/stagemate/global/auth/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,7 +24,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
-@Profile("!local")
+//@Profile("!local")
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -63,6 +64,18 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/", "/login", "/api/v1/auth/**","/login/oauth2/**", "/oauth2/**", "/swagger-ui/**", "/v3/api-docs/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/communities/hot",
+                                "/api/v1/communities",
+                                "/api/v1/communities/trade",
+                                "/api/v1/communities/*"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/magazines/latest",
+                                "/api/v1/magazines/recommend",
+                                "/api/v1/magazines",
+                                "/api/v1/magazines/*"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/stagemate/service/community/CommunityService.java
+++ b/src/main/java/com/example/stagemate/service/community/CommunityService.java
@@ -11,6 +11,9 @@ import com.example.stagemate.repository.ImageRepository;
 import com.example.stagemate.repository.community.*;
 import com.example.stagemate.repository.user.UserJpaRepository;
 import com.example.stagemate.service.image.ImageService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,9 +48,12 @@ public class CommunityService {
     private final CommunityScrapService communityScrapService;
     private final CommunityStatisticsRepository communityStatisticsRepository;
     private final CommunityLikeService communityLikeService;
+    private final ObjectMapper objectMapper;
 
     // 커뮤니티 게시글 작성, 이미지 업로드
-    public CommunityPostResponse createCommunityPost(UserJpaEntity user, CommunityPostCreateRequest request, List<MultipartFile> images) {
+    public CommunityPostResponse createCommunityPost(UserJpaEntity user, CommunityPostCreateRequest request, List<MultipartFile> images) throws JsonProcessingException {
+        // json -> 문자열로 변환
+        String jsonString = objectMapper.writeValueAsString(request.getContent());
         userRepository.findById(user.getId()).orElseThrow(() -> new AppException(NOT_FOUND_USER));
         CommunityCategory communityCategory = CommunityCategory.from(request.getCategory());
         TradeCategory tradeCategory = communityCategory == CommunityCategory.TRADE
@@ -57,7 +63,7 @@ public class CommunityService {
         TradeMethod tradeMethod = communityCategory == CommunityCategory.TRADE
                 ? TradeMethod.from(request.getTradeMethod())
                 : null; // 나눔거래가 아닐 경우 null 처리
-        CommunityPost post = request.toEntity(user, communityCategory, tradeCategory, tradeMethod);
+        CommunityPost post = request.toEntity(user, communityCategory, tradeCategory, tradeMethod, jsonString);
         communityRepository.save(post);
 
         // 이미지가 있다면 업로드 및 연결
@@ -76,9 +82,11 @@ public class CommunityService {
                 post.getImages().add(communityImage);
             }
         }
+        // 역직렬화
+        JsonNode jsonContent = objectMapper.readTree(post.getContent());
 
         // 게시글 작성 시점 사용자는 본인의 스크랩과 좋아요를 누르지 않음
-        return CommunityPostResponse.from(post, false, false);
+        return CommunityPostResponse.from(post, false, false, jsonContent);
     }
 
     // 커뮤니티 게시글 목록 조회(페이징)
@@ -202,7 +210,7 @@ public class CommunityService {
     // 비회원은 전체공개 글만 조회 가능
     // 회원은 전체공개 + 회원공개 글 중 차단한 사람 제외
     // 차단 로직 추후 추가
-    public CommunityPostResponse getCommunityPostDetail(Long postId, UserJpaEntity user) {
+    public CommunityPostResponse getCommunityPostDetail(Long postId, UserJpaEntity user) throws JsonProcessingException {
         CommunityPost post = getCommunityPost(postId);
 
         // 비회원은 전체공개 글만 조회 가능
@@ -225,7 +233,10 @@ public class CommunityService {
             isLiked = communityLikeRepository.existsByUserIdAndCommunityPostId(user.getId(), postId);
         }
 
-        return CommunityPostResponse.from(post, isScrapped, isLiked);
+        // JSON content 파싱
+        JsonNode jsonContent = objectMapper.readTree(post.getContent());
+
+        return CommunityPostResponse.from(post, isScrapped, isLiked, jsonContent);
 
     }
 
@@ -270,7 +281,7 @@ public class CommunityService {
     }
 
 
-    public CommunityPostResponse updateCommunityPost(UserJpaEntity user, Long postId, CommunityPostUpdateRequest request, List<MultipartFile> newImages) {
+    public CommunityPostResponse updateCommunityPost(UserJpaEntity user, Long postId, CommunityPostUpdateRequest request, List<MultipartFile> newImages) throws JsonProcessingException {
         CommunityPost post = communityRepository.findById(postId)
                 .orElseThrow(() -> new AppException(COMMUNITY_POST_NOT_FOUND));
 
@@ -280,7 +291,7 @@ public class CommunityService {
         }
 
         // 게시글 정보 업데이트
-        post.update(request);
+        post.update(request, objectMapper.writeValueAsString(request.getContent()));
 
         // 이미지 업데이트
         updateCommunityPostImage(post, request.getImageIds(), newImages);
@@ -289,7 +300,10 @@ public class CommunityService {
         boolean isScrapped = communityScrapRepository.existsByUserIdAndCommunityPostId(user.getId(), postId);
         boolean isLiked = communityLikeRepository.existsByUserIdAndCommunityPostId(user.getId(), postId);
 
-        return CommunityPostResponse.from(post, isScrapped, isLiked);
+        // 역직렬화
+        JsonNode jsonContent = objectMapper.readTree(post.getContent());
+
+        return CommunityPostResponse.from(post, isScrapped, isLiked, jsonContent);
     }
 
 


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
1. API 문서 및 보안 설정 개선
@CurrentUser 파라미터를 Swagger 문서에 노출되지 않도록 @Parameter(hidden = true) 추가
GET /community, GET /magazine 등 일부 API는 로그인 없이 접근 가능하도록 SecurityConfig 수정

2. 게시글 content 필드 JSON 구조화
content 타입을 String → JsonNode로 변경해 구조화된 텍스트(JSON) 저장 가능
DB에서는 @Lob으로 TEXT 타입으로 저장

4. 커뮤니티 알림 필드(sendNotification) 제거


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링
- [x] 문서 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
