### PR TITLE
refactor : 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/com/example/stagemate/domain/community/CommunityImage.java
+++ b/src/main/java/com/example/stagemate/domain/community/CommunityImage.java
@@ -22,7 +22,7 @@ public class CommunityImage {
     private int sortOrder;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/src/main/java/com/example/stagemate/domain/magazine/MagazineImage.java
+++ b/src/main/java/com/example/stagemate/domain/magazine/MagazineImage.java
@@ -21,7 +21,7 @@ public class MagazineImage {
 
     private int sortOrder;
 
-    @ManyToOne
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/src/main/java/com/example/stagemate/global/exception/image/ImageErrorCode.java
+++ b/src/main/java/com/example/stagemate/global/exception/image/ImageErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ImageErrorCode implements ErrorCode {
 
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.", "IMAGE-001"),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다.", "IMAGE-002"),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/stagemate/service/community/CommunityService.java
+++ b/src/main/java/com/example/stagemate/service/community/CommunityService.java
@@ -5,7 +5,10 @@ import com.example.stagemate.domain.image.Image;
 import com.example.stagemate.domain.user.entity.UserJpaEntity;
 import com.example.stagemate.dto.request.community.CommunityPostCreateRequest;
 import com.example.stagemate.dto.request.community.CommunityPostUpdateRequest;
-import com.example.stagemate.dto.response.community.*;
+import com.example.stagemate.dto.response.community.CommunityCommentResponse;
+import com.example.stagemate.dto.response.community.CommunityPostListResponse;
+import com.example.stagemate.dto.response.community.CommunityPostResponse;
+import com.example.stagemate.dto.response.community.CommunityPostTradeListResponse;
 import com.example.stagemate.global.dto.PagedResponse;
 import com.example.stagemate.global.exception.AppException;
 import com.example.stagemate.repository.ImageRepository;
@@ -27,7 +30,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -344,31 +346,21 @@ public class CommunityService {
         // null 방어 및 effectively final 유지
         List<Long> safeImageIdsToRemain = remainImageIds == null ? List.of() : remainImageIds;
 
-        // 기존 이미지 리스트 복사
-        List<CommunityImage> originalImages = new ArrayList<>(post.getImages());
+        post.getImages().removeIf(communityImage -> {
+            boolean shouldDelete = !safeImageIdsToRemain.contains(communityImage.getImage().getImageId());
+            if (shouldDelete) {
+                // GCS에서 물리적 파일 삭제
+                imageService.deleteImageFromGcs(communityImage.getImage().getImageUrl());
+            }
+            return shouldDelete;
+        });
 
-        // 삭제할 이미지 필터링 (ID 기준)
-        List<CommunityImage> toDelete = originalImages.stream()
-                .filter(img -> !safeImageIdsToRemain.contains(img.getImage().getImageId()))
-                .toList();
+        // 기존 이미지 순서 재정렬
+        post.getImages().sort(Comparator.comparingInt(img -> safeImageIdsToRemain.indexOf(img.getImage().getImageId())));
 
-        for (CommunityImage img : toDelete) {
-            post.getImages().remove(img);
-            img.setCommunityPost(null);
-            communityImageRepository.delete(img);
-            imageRepository.delete(img.getImage());
-        }
-
-        // 남은 이미지 필터링 및 정렬
-        List<CommunityImage> remainImages = post.getImages().stream()
-                .filter(img -> safeImageIdsToRemain.contains(img.getImage().getImageId()))
-                .sorted(Comparator.comparingInt(CommunityImage::getSortOrder))
-                .toList();
-
-        // 정렬 순서 재지정
         int order = 1;
-        for (CommunityImage img : remainImages) {
-            img.setSortOrder(order++);
+        for (CommunityImage communityImage : post.getImages()) {
+            communityImage.setSortOrder(order++);
         }
 
         // 새 이미지 추가
@@ -382,7 +374,6 @@ public class CommunityService {
                         .sortOrder(order++)
                         .build();
                 post.getImages().add(newImage);
-                communityImageRepository.save(newImage);
             }
         }
     }
@@ -394,6 +385,15 @@ public class CommunityService {
         // 게시글 작성자와 요청한 사용자가 일치하는지 확인
         if (!post.getAuthor().getId().equals(user.getId()))
             throw new AppException(COMMUNITY_POST_NOT_AUTHOR);
+
+        // GCS에서 물리적 파일 삭제
+        post.getImages().forEach(communityImage -> {
+            String imageUrl = communityImage.getImage().getImageUrl();
+            imageService.deleteImageFromGcs(imageUrl);
+        });
+
+        // DB에서 CommunityImage, Image 연쇄 삭제
+        post.getImages().clear();
 
         // soft delete 처리
         post.changeIsDeleted();

--- a/src/main/java/com/example/stagemate/service/image/ImageService.java
+++ b/src/main/java/com/example/stagemate/service/image/ImageService.java
@@ -1,13 +1,15 @@
 package com.example.stagemate.service.image;
 
 import com.example.stagemate.domain.image.Image;
+import com.example.stagemate.global.exception.AppException;
 import com.example.stagemate.global.exception.image.ImageUploadFailException;
 import com.example.stagemate.repository.ImageRepository;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,8 +18,10 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import static com.example.stagemate.global.exception.image.ImageErrorCode.IMAGE_DELETE_FAILED;
 import static com.example.stagemate.global.exception.image.ImageErrorCode.IMAGE_UPLOAD_FAILED;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -27,9 +31,6 @@ public class ImageService {
 
     @Value("${spring.cloud.gcp.storage.bucket}") // application.yml에 써둔 bucket 이름
     private String bucketName;
-
-    @Value("${spring.cloud.gcp.storage.project-id}")
-    private String projectId;
 
     public Image uploadImage(MultipartFile input) {
 
@@ -57,6 +58,26 @@ public class ImageService {
 
         } catch (IOException e) {
             throw new ImageUploadFailException(IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    // GCS에서 이미지를 삭제하는 메서드
+    public void deleteImageFromGcs(String imageUrl) {
+        // imageUrl에서 GCS의 파일 이름을 추출
+        String objectName = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+
+        try {
+            // GCS에서 객체 삭제
+            boolean deleted = storage.delete(bucketName, objectName);
+            if (deleted) {
+                log.info("GCS에서 이미지를 성공적으로 삭제했습니다: {}", objectName);
+            } else {
+                log.warn("GCS에서 이미지를 삭제하지 못했습니다 (파일이 존재하지 않을 수 있음): {}", objectName);
+            }
+        } catch (StorageException e) {
+            log.error("GCS 이미지 삭제 중 오류 발생: {}", e.getMessage());
+            throw new AppException(IMAGE_DELETE_FAILED);
+
         }
     }
 

--- a/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
+++ b/src/main/java/com/example/stagemate/service/magazine/MagazineService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.example.stagemate.global.exception.CommonErrorCode.NOT_FOUND_USER;
@@ -122,9 +123,12 @@ public class MagazineService {
     public void deleteMagazine(Long id) {
         Magazine magazine = magazineRepository.findById(id)
                 .orElseThrow(() -> new MagazineNotFoundException(MAGAZINE_NOT_FOUND));
-        for (MagazineImage mi : magazine.getImages()) {
-            imageRepository.delete(mi.getImage());
-        }
+
+        // GCS에 저장된 이미지 삭제
+        new ArrayList<>(magazine.getImages()).forEach(magazineImage -> {
+            imageService.deleteImageFromGcs(magazineImage.getImage().getImageUrl());
+        });
+
         magazineRepository.delete(magazine);
     }
 


### PR DESCRIPTION
## #️⃣ Issue Number

## 📝 요약(Summary)
- GCS 파일 삭제: 게시글/매거진을 삭제하거나 수정할 때, DB뿐만 아니라 GCS에 저장된 실제 이미지 파일도 함께 삭제되도록 수정했습니다.

- 코드 리팩토링: @OneToOne 연관관계 및 cascade 옵션을 활용하여, 불필요한 DB 쿼리를 제거하고 JPA를 통해 연관 데이터가 자동으로 관리되도록 코드를 간소화했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
